### PR TITLE
Make whisper command execution safer and simpler

### DIFF
--- a/src/utils/transcription_utils.py
+++ b/src/utils/transcription_utils.py
@@ -1,5 +1,4 @@
 import subprocess
-import shlex
 
 from src.api.config import HF_TOKEN
 
@@ -7,10 +6,21 @@ from src.api.config import HF_TOKEN
 def run_whisperx(temp_mp3_path, lang, model, min_speakers, max_speakers):
     output_dir = "./data/"
     if min_speakers > 0 and max_speakers > 0:
-        cmd = (f"whisperx {shlex.quote(temp_mp3_path)} --model {model} --language {lang} --hf_token {HF_TOKEN} --output_format all "
-               f"--output_dir {output_dir}  --align_model WAV2VEC2_ASR_LARGE_LV60K_960H --diarize --min_sp"
-               f"eakers {min_speakers} --max_speakers {max_speakers}")
+        cmd = ["whisperx", temp_mp3_path,
+               "--model", model,
+               "--language", lang,
+               "--hf_token", HF_TOKEN,
+               "--output_format", "all",
+               "--output_dir", output_dir,
+               "--align_model", "WAV2VEC2_ASR_LARGE_LV60K_960H",
+               "--diarize",
+               "--min_speakers", min_speakers,
+               "--max_speakers" max_speakers]
     else:
-        cmd = (f"whisperx {shlex.quote(temp_mp3_path)} --model {model} --language {lang} --output_format all "
-               f"--output_dir {output_dir}  --align_model WAV2VEC2_ASR_LARGE_LV60K_960H")
-    subprocess.run(shlex.split(cmd), check=True)
+        cmd = ["whisperx", temp_mp3_path,
+               "--model", model,
+               "--language", lang,
+               "--output_format", "all",
+               "--output_dir", output_dir,
+               "--align_model", "WAV2VEC2_ASR_LARGE_LV60K_960H"]
+    subprocess.run(cmd, check=True)


### PR DESCRIPTION
Commit 9cc5c66 fixes the problem of command argument splitting not working correctly. But why do we convert everything to a string in the first place only to then try to generate a list from that string? It's much easier and safer to just put all arguments into a list right from the start.

I haven't actually tested this, but I'm pretty confident that this works.